### PR TITLE
Fix content size after resize

### DIFF
--- a/src/js/jquery.smartWizard.js
+++ b/src/js/jquery.smartWizard.js
@@ -555,7 +555,7 @@
                 css_left  = selPage.css("left");
                 selPage.css("position", 'absolute')
                         .css("left", nextFirstLeft)
-                        .outerWidth(containerWidth)
+                        .outerWidth("auto")
                         .show()
                         .animate({
                           left: 0


### PR DESCRIPTION
### Fixes:
  -  Fix bug where, after resizing a browser window, the content inside the wizard isn't the right width and so goes out of the wizard boundary

### Changes:
  -  Changed the width to be "auto"
