### PR TITLE
Add "loaded" event

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -144,6 +144,10 @@
                 }
             });
 
+            $("#smartwizard").on("loaded", function(e) {
+                console.log("loaded");
+            });
+
             // Smart Wizard
             $('#smartwizard').smartWizard({
                 selected: 0,

--- a/src/js/jquery.smartWizard.js
+++ b/src/js/jquery.smartWizard.js
@@ -120,6 +120,7 @@
           this._setPreviousStepsDone(idx);
           // Show the initial step
           this._showStep(idx);
+          this._triggerEvent("loaded");
       }
 
       // Initialize options

--- a/test/test.js
+++ b/test/test.js
@@ -55,3 +55,21 @@ describe('SmartWizard Navigation', function() {
     });
 
 });
+
+describe('SmartWizard widget', () => {
+    it('should trigger "loaded" event', () => {
+        jasmine.getFixtures().fixturesPath = 'base/test';
+        loadFixtures('test-template.html');
+
+        var loadedEventSpy = jasmine.createSpy("loaded");
+        var el = $('#smartwizard');
+
+        $(el).bind("loaded", loadedEventSpy);
+
+        expect(loadedEventSpy).not.toHaveBeenCalled();
+
+        el.smartWizard();
+
+        expect(loadedEventSpy).toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
Having a "loaded" event triggered right after the widget has been loaded could be useful, e.g. for showing spinner while it's loading and hiding it afterwards.